### PR TITLE
Fix layout broken on devices safe area

### DIFF
--- a/SurveysChallenge/Storyboards/Base.lproj/Main.storyboard
+++ b/SurveysChallenge/Storyboards/Base.lproj/Main.storyboard
@@ -49,10 +49,10 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="NGP-0e-idf" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="96T-cO-hfC"/>
+                            <constraint firstAttribute="bottom" secondItem="NGP-0e-idf" secondAttribute="bottom" id="9rw-Zt-Gi1"/>
                             <constraint firstItem="DjL-Y6-P9q" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="I4c-O5-26P"/>
                             <constraint firstItem="DjL-Y6-P9q" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="II2-1N-v87"/>
                             <constraint firstItem="NGP-0e-idf" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="MGm-XE-iOx"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="NGP-0e-idf" secondAttribute="bottom" id="Owd-m9-KMk"/>
                             <constraint firstItem="Mlz-Co-hWb" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="rQL-Ra-5Ak"/>
                             <constraint firstItem="Mlz-Co-hWb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" multiplier="1.9" id="u4D-1U-7M7"/>
                             <constraint firstItem="NGP-0e-idf" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="xEx-5G-vRQ"/>
@@ -108,7 +108,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Tti-4N-D0W" firstAttribute="bottom" secondItem="TUd-jW-3IH" secondAttribute="bottom" id="3CM-Ln-d0K"/>
+                            <constraint firstAttribute="bottom" secondItem="TUd-jW-3IH" secondAttribute="bottom" id="3CM-Ln-d0K"/>
                             <constraint firstItem="Tti-4N-D0W" firstAttribute="trailing" secondItem="cKH-IJ-z8Q" secondAttribute="trailing" constant="30" id="6Rk-ph-YQ5"/>
                             <constraint firstItem="TUd-jW-3IH" firstAttribute="top" secondItem="Tti-4N-D0W" secondAttribute="top" id="8FT-jQ-chE"/>
                             <constraint firstItem="IJJ-1H-YbM" firstAttribute="leading" secondItem="LO9-F0-Aex" secondAttribute="leading" constant="20" id="DY7-Uz-Kq6"/>
@@ -116,7 +116,7 @@
                             <constraint firstItem="Gcq-fW-9mv" firstAttribute="leading" secondItem="Tti-4N-D0W" secondAttribute="leading" id="GJ2-hC-gES"/>
                             <constraint firstItem="Tti-4N-D0W" firstAttribute="trailing" secondItem="TUd-jW-3IH" secondAttribute="trailing" id="JY0-5f-3ei"/>
                             <constraint firstItem="cKH-IJ-z8Q" firstAttribute="top" secondItem="Tti-4N-D0W" secondAttribute="top" constant="150" id="Jb4-Cb-Kqp"/>
-                            <constraint firstItem="Gcq-fW-9mv" firstAttribute="bottom" secondItem="Tti-4N-D0W" secondAttribute="bottom" id="fQ4-2Q-H2e"/>
+                            <constraint firstItem="Gcq-fW-9mv" firstAttribute="bottom" secondItem="LO9-F0-Aex" secondAttribute="bottom" id="fQ4-2Q-H2e"/>
                             <constraint firstItem="TUd-jW-3IH" firstAttribute="leading" secondItem="Tti-4N-D0W" secondAttribute="leading" id="hEm-5q-XXs"/>
                             <constraint firstItem="Gcq-fW-9mv" firstAttribute="trailing" secondItem="Tti-4N-D0W" secondAttribute="trailing" id="kis-z3-Ove"/>
                             <constraint firstItem="Gcq-fW-9mv" firstAttribute="top" secondItem="Tti-4N-D0W" secondAttribute="top" id="t80-Q6-2AU"/>

--- a/SurveysChallenge/ViewControllers/MainSurveysViewController.swift
+++ b/SurveysChallenge/ViewControllers/MainSurveysViewController.swift
@@ -54,9 +54,7 @@ final class MainSurveysViewController: BaseViewController, SurveyListViewType {
     private func setupUI() {
         loadingIndicatorView.startAnimating()
         pageControl.customBorderColor = .white
-        tableView.estimatedRowHeight = tableView.frame.size.height
         tableView.addSubview(refreshControl)
-        tableView.rowHeight = tableView.frame.size.height
         tableView.register(UINib(nibName: SurveyCell.typeName, bundle: nil), forCellReuseIdentifier: SurveyCell.typeName) 
     }
 
@@ -76,7 +74,7 @@ final class MainSurveysViewController: BaseViewController, SurveyListViewType {
             .filter({ [unowned self] in self.refreshControl.isRefreshing })
             .bind(to: viewModel.onRefresh)
             .disposed(by: disposeBag)
-
+        
         tableView.rx.contentOffset
             .filter { [unowned self] offset in
                 guard self.tableView.contentSize.height > 0 else { return false }
@@ -116,7 +114,7 @@ final class MainSurveysViewController: BaseViewController, SurveyListViewType {
     }
 }
 
-extension MainSurveysViewController: UITableViewDataSource, UITableViewDelegate {
+extension MainSurveysViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.surveys.count
     }
@@ -131,6 +129,16 @@ extension MainSurveysViewController: UITableViewDataSource, UITableViewDelegate 
             }
         }
         return cell
+    }
+}
+
+extension MainSurveysViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return tableView.frame.size.height
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return tableView.frame.size.height
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {


### PR DESCRIPTION
#### What does this PR do?
- Fix issue: https://github.com/hoangcanhsek6/SurveysChallenge/issues/8
- Fix layout broken with devices with safe area type. 

#### Where should the reviewer start?
- Files changed.
#### How should this be manually tested?
- Re-run the app and test around.

#### Any background context you want to provide?
- Was intended to make the code shorter by set the row height and estimate row in viewDidLoad instead of the delegate. We can set it in viewDidAppear but anyway to make it simple just bring it back as normal.

#### What are the relevant tickets?
Github issue: https://github.com/hoangcanhsek6/SurveysChallenge/issues/8

#### Screenshots (if appropriate)
![layout_fix](https://user-images.githubusercontent.com/7752679/56258991-b9b1b600-60fb-11e9-96eb-20b8b9d271c2.gif)


#### Questions
N/A